### PR TITLE
adds toggleable filters, fixes svg icons path #348

### DIFF
--- a/_includes/wai-course-list/css/filters.css
+++ b/_includes/wai-course-list/css/filters.css
@@ -1,0 +1,64 @@
+.button--skip-link:not(:focus):not(:hover) {
+    transform: translateY(-4em);
+    opacity: 0;
+}
+
+.button--skip-link {
+    transform: translateY(-4em);
+    opacity: 0;
+    display: table-column;
+}
+
+.button--skip-link {
+    background-color: var(--gold) !important;
+    border-color: var(--gold) !important;
+    outline-color: currentColor !important;
+    color: var(--off-black) !important;
+    font-weight: 600;
+    font-size: larger;
+    margin: 0 auto;
+    position: absolute;
+    z-index: 20;
+    left: 0;
+    right: 0;
+    top: 0.5em;
+    width: 10em;
+    opacity: 1;
+    transition: transform 0.1875s ease-out, opacity 0.1875s ease-out;
+}
+
+.open {
+    display: block !important;
+}
+
+.closed {
+    display: none !important;
+}
+
+.data-filter-form {
+    display: block;
+}
+
+.button-filters {
+    display: none;
+}
+
+.close-filters {
+    display: none;
+}
+
+
+@media (max-width: 59em) {
+    .data-filter-form {
+        display: none;
+    }
+
+    .button-filters {
+        display: block;
+    }
+
+    .close-filters {
+        display: block;
+    }
+}
+

--- a/_includes/wai-course-list/js/filters.js
+++ b/_includes/wai-course-list/js/filters.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', function (event) {
+  const filterForm = document.querySelector('.data-filter-form')
+
+  console.log(filterForm)
+
+  function toggleFilters() {
+    if (!filterForm.classList.contains('open')) {
+      filterForm.classList.add('open')
+      document.querySelector('.button-filters').classList.add('closed')
+    } else {
+      filterForm.classList.remove('open')
+      document.querySelector('.button-filters').classList.remove('closed')
+    }
+  }
+
+  document.querySelector('.button-filters').addEventListener('click', (e) => {
+    toggleFilters()
+  })
+
+  document.querySelector('.close-filters').addEventListener('click', (e) => {
+    toggleFilters()
+  })
+})

--- a/content/index.md
+++ b/content/index.md
@@ -20,7 +20,9 @@ footer: >
 ---
 <!-- markdownlint-disable no-inline-html -->
 
-<style>{% include wai-course-list/css/styles.css %}
+<style>
+{% include wai-course-list/css/styles.css %}
+{% include wai-course-list/css/filters.css %}
 </style>
 {% assign strings = site.data.wai-course-list.strings %}
 <div class="header-sup">
@@ -43,12 +45,17 @@ footer: >
 {% assign defaultSort = site.data.wai-course-list.sorting.first.sortkey %}
 {% include wai-course-list/sort-data-folder.liquid data=site.data.wai-course-list.submissions sortKey=defaultSort %}<div id="app">
     <div id="left-col" class="courses-filters">
-        <form data-filter-form action="...">
-            <h2 id="filters_title">{{ strings.filters_title }}</h2>
+        <h2 class="visuallyhidden">Filters</h2>
+        <button class="button button-filters" aria-haspopup="true" aria-expanded="false" id="openfilters">Filters</button>
+        <form data-filter-form action="..." class="data-filter-form">
+            <div class="filter-header">
+                <a class="close-filters"><svg focusable="false" aria-hidden="true" class="icon-ex-circle "><use xlink:href="../../assets/images/icons.svg#icon-ex-circle"></use></svg></a>
+            </div>
             {% include box.html type="start" class="simple infobox"%}
-            <svg focusable="false" aria-label="Information about the filters" class="i-info"><use xlink:href="/assets/images/icons.svg#icon-info"></use></svg>
+            <svg focusable="false" aria-label="Information about the filters" class="i-info"><use xlink:href="../../assets/images/icons.svg#icon-info"></use></svg>
             {{strings.filters_info}}
             {% include box.html type="end" %}
+            <a href="#tools-list" class="button button--skip-link">Skip filters</a>
             {% for filter in site.data.wai-course-list.filters %}
             <fieldset id="{{ filter.id }}">
                 {% if filter.info %}
@@ -163,4 +170,7 @@ footer: >
 </div>
 <script>
 {% include wai-course-list/js/courses.js %}
+{% include wai-course-list/js/filters.js %}
 </script>
+<style>
+</style>

--- a/content/submit-a-resource.md
+++ b/content/submit-a-resource.md
@@ -452,7 +452,7 @@ function onSubmit(e) {
 
 <div id="preview-submission-overlay" role="dialog" aria-modal="true" aria-labelledby="preview_title">
 <div class="overlay-content">
-  <button class="button button-close_preview icon" title="{{strings.close_back_to_form}}"><span><svg focusable="false" aria-hidden="true" class="icon-ex-circle "><use xlink:href="/WAI/assets/images/icons.svg#icon-ex-circle"></use></svg> </span></button>
+  <button class="button button-close_preview icon" title="{{strings.close_back_to_form}}"><span><svg focusable="false" aria-hidden="true" class="icon-ex-circle "><use xlink:href="../../assets/images/icons.svg#icon-ex-circle"></use></svg> </span></button>
   <h2 id="preview_title">{{ strings.preview_title }}</h2>  
   <p>{{ strings.preview_info }}</p>
   <div class="details-preview box"></div>


### PR DESCRIPTION
Hi, Shawn!

I did two things in this commit:

**[1]** Added the filters button and its functionality (`filters.css`, `filters.js`) and skip filters link `index.md`. I tried to emulate this: [wai-evaluation-tools-list](https://github.com/w3c/wai-evaluation-tools-list)

The breakpoint to show the filters button/logic is @media (max-width: 59em); if we want to emulate [wai-evaluation-tools-list](https://github.com/w3c/wai-evaluation-tools-list), it should be 60em, but for some reason, the grid style doesn't disappear at 60em, maybe a (margin, border, padding, width, etc.) somewhere prevents it from working correctly. 

**[2]** Fixed the path that fixes the network error (404) when trying to GET the resource (`icons.svg`). Now it works locally, and it should work in production. I attach the following image to illustrate the error:

[![Screenshot-2022-09-26-at-00-35-10.png](https://i.postimg.cc/T1nxwDC7/Screenshot-2022-09-26-at-00-35-10.png)](https://postimg.cc/tnRwvY0W)

Please, tell me if this issue needs further modifications. 🙂

All the best,
Jordi