### PR TITLE
Display course provider and start date in form submission PRs for easier management

### DIFF
--- a/.github/workflows/process-form-submission.yml
+++ b/.github/workflows/process-form-submission.yml
@@ -31,7 +31,7 @@ jobs:
           branch: form-submission/${{ github.event.client_payload.form.submission_ref }}
           branch-suffix: random # handle concurrent submissions of same form id
           delete-branch: true
-          title: "New form submission: from ${{ github.event.client_payload.form.provider }}, starting ${{ github.event.client_payload.form.start_date }}"
+          title: "New course: by ${{ github.event.client_payload.form.provider }}, starting ${{ github.event.client_payload.form.start_date }}"
           body: |
             New form submission:
             - title: ${{ github.event.client_payload.form.title }}

--- a/.github/workflows/process-form-submission.yml
+++ b/.github/workflows/process-form-submission.yml
@@ -31,11 +31,12 @@ jobs:
           branch: form-submission/${{ github.event.client_payload.form.submission_ref }}
           branch-suffix: random # handle concurrent submissions of same form id
           delete-branch: true
-          title: "New form submission '${{ github.event.client_payload.form.form_name }}' - ${{ github.event.client_payload.form.submission_ref }}"
+          title: "New form submission: from ${{ github.event.client_payload.form.provider }}, starting ${{ github.event.client_payload.form.start_date }}"
           body: |
             New form submission:
-
-            - form_name: ${{ github.event.client_payload.form.form_name }}
+            - title: ${{ github.event.client_payload.form.title }}
+            - provider: ${{ github.event.client_payload.form.provider }}
+            - start_date: ${{ github.event.client_payload.form.start_date }}
             - form_version: ${{ github.event.client_payload.form.form_version }}
             - submission_ref: ${{ github.event.client_payload.form.submission_ref }}
             - submission_date: ${{ github.event.client_payload.form.submission_date }}

--- a/.github/workflows/process-form-submission.yml
+++ b/.github/workflows/process-form-submission.yml
@@ -37,7 +37,6 @@ jobs:
             - title: ${{ github.event.client_payload.form.title }}
             - provider: ${{ github.event.client_payload.form.provider }}
             - start_date: ${{ github.event.client_payload.form.start_date }}
-            - form_version: ${{ github.event.client_payload.form.form_version }}
             - submission_ref: ${{ github.event.client_payload.form.submission_ref }}
             - submission_date: ${{ github.event.client_payload.form.submission_date }}
 


### PR DESCRIPTION
This PR displays the course provider name and start date in the PR titles, instead of `form_name` (always "submission") and UUID.

I chose not to use the course title in the PR title because it might be long, and favored the start date to facilitate review prioritization.

This PR also adds this information (+ the course title) to the PR description, in replacement of `form_name` (always "submission") and `form_version` (always "1").

PR title would be:

```
New course: by ACME Inc, starting 2025-05-21
```

Instead of:

```
New form submission 'submission' - 31e59c21-3354-47e2-b978-d89c4f6777e6
```

